### PR TITLE
Update TildeETerminology.java

### DIFF
--- a/tilde-services/src/main/java/eu/freme/eservices/tilde/terminology/TildeETerminology.java
+++ b/tilde-services/src/main/java/eu/freme/eservices/tilde/terminology/TildeETerminology.java
@@ -78,7 +78,7 @@ public class TildeETerminology extends BaseRestController {
 			@RequestParam(value = "domain", defaultValue = "") String domain,
 			@RequestParam(value = "mode", defaultValue = "full") String mode,
 			@RequestParam(value = "collection", required = false) String collection,
-			@RequestHeader(value = "key", required= false) String key,
+			@RequestParam(value = "key", required= false) String key,
 			@RequestParam(value = "nif-version", required = false) String nifVersion
 	) {
 		// merge long and short parameters - long parameters override short


### PR DESCRIPTION
Documentation sends private key as query parameter not header. Same as for e-translations.